### PR TITLE
feat メニュー表示まで実装

### DIFF
--- a/menu-list-frontend/.env.development
+++ b/menu-list-frontend/.env.development
@@ -1,1 +1,1 @@
-NEXT_PUBLIC_S3_JSON_ENDPOINT=https://tasuku-dev-json.s3.ap-northeast-1.amazonaws.com
+NEXT_PUBLIC_S3_JSON_ENDPOINT=http://localhost:3000

--- a/menu-list-frontend/declarations/menu.ts
+++ b/menu-list-frontend/declarations/menu.ts
@@ -1,7 +1,7 @@
 import { Nullable, ValueOf } from './utils';
 import { MENU_STATUS } from '../const/menu';
 
-export type Product = {
+export type Menu = {
     id: number,
     title: string,
     image_url: Nullable<string>,

--- a/menu-list-frontend/declarations/menu.ts
+++ b/menu-list-frontend/declarations/menu.ts
@@ -10,11 +10,26 @@ export type Menu = {
     status: ValueOf<typeof MENU_STATUS>,
     is_child: boolean,
     is_recommend: boolean,
-    topping: Topping[],
-    childen: number[],
+    topping: Topping[]|[],
+    childen: number[]|[],
     category: number,
     sort_number: number,
 };
+
+export type ConvertedMenu = {
+    id: number,
+    title: string,
+    image_url: Nullable<string>,
+    description: Nullable<string>,
+    price: number,
+    status: ValueOf<typeof MENU_STATUS>,
+    is_child: boolean,
+    is_recommend: boolean,
+    topping: Topping[],
+    childen: Menu[]|[],
+    category: number,
+    sort_number: number,
+}
 
 export type Topping = {
     title: string,

--- a/menu-list-frontend/pages/index.tsx
+++ b/menu-list-frontend/pages/index.tsx
@@ -4,21 +4,39 @@ import { useDispatch, useSelector } from 'react-redux'
 import { AppDispatch } from '../redux/store'
 import { useEffect } from 'react'
 import { categoriesSelector } from '../redux/selector/category'
+import { fetchMenus } from '../redux/modules/menu'
+import { menusSelector } from '../redux/selector/menu'
 
 const Home: NextPage = () => {
   const dispatch: AppDispatch = useDispatch();
   useEffect(() => {
     dispatch(fetchCategories());
+    dispatch(fetchMenus());
   }, []);
   const categories = useSelector(categoriesSelector);
+  const menus = useSelector(menusSelector);
   return (
-    <ul>
-      <p>すべて</p>
-      <p>おすすめ</p>
-      {categories.map((category) => (
-        <p key={category.sort_number}>{category.title}</p>
-      ))}
-    </ul>
+    <>
+      <div>
+        <p>カテゴリ</p>
+        <ul>
+          <li>すべて</li>
+          <li>おすすめ</li>
+          {categories.map((category) => (
+            <li key={category.sort_number}>{category.title}</li>
+          ))}
+        </ul>
+      </div>
+      <div>
+        <p>メニュー</p>
+        <ul>
+          {menus.map((menu) => (
+            <li key={menu.id}>{menu.title} : {menu.price}円</li>
+          ))}
+        </ul>
+      </div>
+
+    </>
   )
 }
 

--- a/menu-list-frontend/public/categories.json
+++ b/menu-list-frontend/public/categories.json
@@ -1,0 +1,19 @@
+{
+    "categories":[
+        {
+            "id": 1,
+            "title": "辛麺",
+            "sort_number": 1
+        },
+        {
+            "id": 2,
+            "title": "ドリンク",
+            "sort_number": 3
+        },
+        {
+            "id": 3,
+            "title": "一品",
+            "sort_number": 2
+        }
+    ]
+}

--- a/menu-list-frontend/public/menus.json
+++ b/menu-list-frontend/public/menus.json
@@ -1,0 +1,126 @@
+{
+    "menus": [
+        {
+            "id": 1,
+            "title": "辛麺",
+            "image_url": "https://placehold.jp/150x150.png",
+            "description": "辛麺です。",
+            "price": 500,
+            "status": "publishing",
+            "is_child": false,
+            "is_recommend": true,
+            "topping": [
+                {
+                    "title": "たまご",
+                    "price": 100
+                },
+                {
+                    "title": "チーズ",
+                    "price": 200
+                }
+            ],
+            "childen": [
+                3,
+                4
+            ],
+            "category": 1,
+            "sort_number": 1
+        },
+        {
+            "id": 2,
+            "title": "坦々麺",
+            "image_url": "https://placehold.jp/150x150.png",
+            "description": "",
+            "price": 500,
+            "status": "sold_out",
+            "is_child": false,
+            "is_recommend": true,
+            "topping": [
+                {
+                    "title": "たまご",
+                    "price": 100
+                },
+                {
+                    "title": "チーズ",
+                    "price": 200
+                }
+            ],
+            "childen": [],
+            "category": 1,
+            "sort_number": 1
+        },
+        {
+            "id": 3,
+            "title": "おでん",
+            "image_url": "https://placehold.jp/150x150.png",
+            "description": "おでんです。",
+            "price": 100,
+            "status": "publishing",
+            "is_child": false,
+            "is_recommend": false,
+            "topping": [],
+            "childen": [
+                4,
+                5
+            ],
+            "category": 3,
+            "sort_number": 1
+        },
+        {
+            "id": 4,
+            "title": "おでん(玉子)",
+            "image_url": "https://placehold.jp/150x150.png",
+            "description": "",
+            "price": 100,
+            "status": "publishing",
+            "is_child": true,
+            "is_recommend": false,
+            "topping": [],
+            "childen": [],
+            "category": 3,
+            "sort_number": 2
+        },
+        {
+            "id": 5,
+            "title": "おでん(大根)",
+            "image_url": "https://placehold.jp/150x150.png",
+            "description": "",
+            "price": 100,
+            "status": "publishing",
+            "is_child": true,
+            "is_recommend": false,
+            "topping": [],
+            "childen": [],
+            "category": 3,
+            "sort_number": 3
+        },
+        {
+            "id": 6,
+            "title": "ビール",
+            "image_url": "https://placehold.jp/150x150.png",
+            "description": "ビールです。",
+            "price": 600,
+            "status": "publishing",
+            "is_child": false,
+            "is_recommend": false,
+            "topping": [],
+            "childen": [],
+            "category": 4,
+            "sort_number": 1
+        },
+        {
+            "id": 6,
+            "title": "表示されないアイテム",
+            "image_url": "https://placehold.jp/150x150.png",
+            "description": "",
+            "price": 500,
+            "status": "closed",
+            "is_child": false,
+            "is_recommend": false,
+            "topping": [],
+            "childen": [],
+            "category": 1,
+            "sort_number": 3
+        }
+    ]
+}

--- a/menu-list-frontend/redux/modules/menu/index.ts
+++ b/menu-list-frontend/redux/modules/menu/index.ts
@@ -1,5 +1,20 @@
-import { createSlice } from "@reduxjs/toolkit";
+import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
+import { ThunkApi } from "../../../declarations";
 import { Menu } from "../../../declarations/menu"
+import * as menuServices from "../../../services/menu";
+
+export const fetchMenus = createAsyncThunk<{menus: Menu[]}, void, ThunkApi>(
+    'menu/fetchMenus',
+    async (_, thunkApi) => {
+        try {
+            const response = await menuServices.fetchMenus();
+            return response.data;
+          } catch (err: any) {
+            return thunkApi.rejectWithValue(err.response.data);
+          }
+    }
+);
+
 
 type MenuState = {
     menus: Menu[]|[]
@@ -13,6 +28,15 @@ export const slice = createSlice({
     name: 'menu',
     initialState,
     reducers: {
+    },
+    extraReducers: (builder) => {
+        builder.addCase(fetchMenus.fulfilled, (state, payload: { payload: { menus: Menu[]} }) => {
+            state.menus = payload.payload.menus;
+        });
+        builder.addCase(fetchMenus.rejected, (_, { payload }: { payload: unknown }) => {
+            // TODO エラー処理の場合を考える
+            console.log(payload);
+        });
     },
 });
 

--- a/menu-list-frontend/redux/modules/menu/index.ts
+++ b/menu-list-frontend/redux/modules/menu/index.ts
@@ -1,7 +1,17 @@
 import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
+import { Children } from "react";
 import { ThunkApi } from "../../../declarations";
-import { Menu } from "../../../declarations/menu"
+import { ConvertedMenu, Menu } from "../../../declarations/menu"
 import * as menuServices from "../../../services/menu";
+
+const convertMenu = (menus: Menu[]): ConvertedMenu[] => {
+    return menus.map((menu) => {
+        const children = menus.filter((_m) => {
+            return menu.childen.some((id) => id === _m.id && _m.is_child);
+        })
+        return { ...menu, childen: children}
+    });
+}
 
 export const fetchMenus = createAsyncThunk<{menus: Menu[]}, void, ThunkApi>(
     'menu/fetchMenus',
@@ -15,9 +25,8 @@ export const fetchMenus = createAsyncThunk<{menus: Menu[]}, void, ThunkApi>(
     }
 );
 
-
 type MenuState = {
-    menus: Menu[]|[]
+    menus: ConvertedMenu[]|[]
 };
 
 export const initialState: MenuState = {
@@ -31,7 +40,7 @@ export const slice = createSlice({
     },
     extraReducers: (builder) => {
         builder.addCase(fetchMenus.fulfilled, (state, payload: { payload: { menus: Menu[]} }) => {
-            state.menus = payload.payload.menus;
+            state.menus = convertMenu(payload.payload.menus);
         });
         builder.addCase(fetchMenus.rejected, (_, { payload }: { payload: unknown }) => {
             // TODO エラー処理の場合を考える

--- a/menu-list-frontend/redux/modules/menu/index.ts
+++ b/menu-list-frontend/redux/modules/menu/index.ts
@@ -1,0 +1,19 @@
+import { createSlice } from "@reduxjs/toolkit";
+import { Menu } from "../../../declarations/menu"
+
+type MenuState = {
+    menus: Menu[]|[]
+};
+
+export const initialState: MenuState = {
+    menus: []
+};
+
+export const slice = createSlice({
+    name: 'menu',
+    initialState,
+    reducers: {
+    },
+});
+
+export default slice.reducer;

--- a/menu-list-frontend/redux/rootReducer.ts
+++ b/menu-list-frontend/redux/rootReducer.ts
@@ -1,8 +1,10 @@
 import { combineReducers } from '@reduxjs/toolkit';
 import categoryReducer from './modules/category';
+import menuReducer from './modules/menu';
 
 const rootReducer = combineReducers({
     category: categoryReducer,
+    menu: menuReducer,
 });
 
 export type RootState = ReturnType<typeof rootReducer>;

--- a/menu-list-frontend/redux/selector/menu/index.ts
+++ b/menu-list-frontend/redux/selector/menu/index.ts
@@ -1,0 +1,10 @@
+import { createSelector } from 'reselect';
+import { MENU_STATUS } from '../../../const/menu';
+import { RootState } from '../../rootReducer';
+
+export const menusSelector = createSelector(
+    (state: RootState) => state.menu,
+    ({ menus }) => {
+        return menus.filter((menu) => { return !menu.is_child && menu.status === MENU_STATUS.PUBLISHING });
+    }
+);


### PR DESCRIPTION
## issue
#2  
#9

## 内容
メニューをjsonから取得してstoreに保存、一覧表示まで作成。
store格納時に子メニューのidをメニューに変換してるので実装時楽かと！
あと取得先のjsonをローカルに持つようにしたので色々試したければ直接いじってもらえると反映されます！

ちなみに既知かもだけど`Redux Dev-tools`ってやるを入れるとredux内のstoreの状態が見れるのでおすすめ！
